### PR TITLE
feat(input): Add user input

### DIFF
--- a/src/extend.js
+++ b/src/extend.js
@@ -10,7 +10,7 @@ import { includes } from './util'
  * @return {String}       The extended morse code
  */
 function extend (morse) {
-  const noiseGlyphes = ['.', '-']
+  const noiseGlyphes = ['·', '-']
 
   return morse.replace(' / ', '/').split('').reduce((acc, curr, i, arr) => {
     return includes(noiseGlyphes, curr, arr[i + 1])

--- a/src/index.html
+++ b/src/index.html
@@ -5,9 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body>
-    <h1>hello, world</h1>
+    <h1>Phone vibrations from morse code?! In the browser?! Wooh!</h1>
+    <p>
+      The main purpose of this demonstration is to highlight some things
+      you could possibly do with the Vibration API.
+    </p>
+    <p>Some other ideas...</p>
+    <ul>
+      <li>Vibration feedback for HTML5 mobile games</li>
+      <li>An "infection"-esk augmented reality game; your phone's vibration pattern depends on the infected's proximity</li>
+    </ul>
+    <hr>
+    <p>
+      Enter a message below. The message will be transmitted to you in morse code,
+      <i>through vibrations from your phone</i> (if you're on one). If you liked the demo,
+      please consider giving me a <a href="https://github.com/ScottyFillups/morse-pulse">star</a>! c:
+    </p>
+    <form id="morse-form">
+      <label for="message">Star Our Source:</label>
+      <input type="text" id="message">
+      <input type="submit" id="pulsify" value="Pulse up!">
+    </form>
     <p id="morse"></p>
-    <button id="pulsify">Morse up!</button>
     <script src="./index.js"></script>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,17 @@ import pulsemap from './pulsemap'
 import { $ } from './util'
 
 const morse = new Morsey()
-const message = 'hello, world'
-const hello = morse.encode(message)
-const pulses = pulsemap(hello)
 
-$('#pulsify').addEventListener('click', (e) => {
-  $('#morse').innerHTML = hello
+let encoded
+let pulses
+
+$('#morse-form').addEventListener('submit', (e) => {
+  e.preventDefault()
+
+  encoded = morse.encode($('#message').value)
+  pulses = pulsemap(encoded, { factor: 500 })
+
+  $('#morse').innerHTML = encoded
+
   window.navigator.vibrate(pulses)
 })

--- a/src/pulsemap.js
+++ b/src/pulsemap.js
@@ -20,7 +20,7 @@ function pulsemap (morse, config = {}) {
       case '*':
         delay = 1
         break
-      case '.':
+      case '·':
         delay = 1
         break
       case '-':

--- a/test/test.js
+++ b/test/test.js
@@ -34,15 +34,15 @@ describe('pulsemap library', () => {
 
   describe('extend maps morse code to extended morse', () => {
     it('correctly maps a simple morse code string', () => {
-      const hello = '.... . .-.. .-.. ---'
-      const extended = '.*.*.*. . .*-*.*. .*-*.*. -*-*-'
+      const hello = '···· · ·-·· ·-·· ---'
+      const extended = '·*·*·*· · ·*-*·*· ·*-*·*· -*-*-'
 
       expect(extend(hello)).to.equal(extended)
     })
 
     it('correctly maps a "complicated" morse code string', () => {
-      const helloWorld = '.... . .-.. .-.. --- --..-- / .-- --- .-. .-.. -..'
-      const extended = '.*.*.*. . .*-*.*. .*-*.*. -*-*- -*-*.*.*-*-/.*-*- -*-*- .*-*. .*-*.*. -*.*.'
+      const helloWorld = '···· · ·-·· ·-·· --- --··-- / ·-- --- ·-· ·-·· -··'
+      const extended = '·*·*·*· · ·*-*·*· ·*-*·*· -*-*- -*-*·*·*-*-/·*-*- -*-*- ·*-*· ·*-*·*· -*·*·'
 
       expect(extend(helloWorld)).to.equal(extended)
     })
@@ -50,7 +50,7 @@ describe('pulsemap library', () => {
 
   describe('pulsemap maps morse code strings to numbers', () => {
     it('correctly maps a simple morse code string', () => {
-      const hello = '.... . .-.. .-.. ---'
+      const hello = '···· · ·-·· ·-·· ---'
       const pulses = [
         1000, 1000, 1000, 1000, 1000, 1000, 1000, 3000,
         1000, 3000,
@@ -63,7 +63,7 @@ describe('pulsemap library', () => {
     })
 
     it('correctly maps a "complicated" morse code string', () => {
-      const helloWorld = '.... . .-.. .-.. --- --..-- / .-- --- .-. .-.. -..'
+      const helloWorld = '···· · ·-·· ·-·· --- --··-- / ·-- --- ·-· ·-·· -··'
       const pulses = [
         1000, 1000, 1000, 1000, 1000, 1000, 1000, 3000,
         1000, 3000,
@@ -82,7 +82,7 @@ describe('pulsemap library', () => {
     })
 
     it('accepts custom delay factors', () => {
-      const hello = '.... . .-.. .-.. ---'
+      const hello = '···· · ·-·· ·-·· ---'
       const config = { factor: 10 }
       const pulses = [
         10, 10, 10, 10, 10, 10, 10, 30,


### PR DESCRIPTION
## Context

Right now users cannot submit their own messages to test out. There should be a form on the page that will allow them to turn any arbitrary message into morse code, and receive it via phone vibrations.

## Objective

* Add input form for users to `pulsify` their own messages

## Lessons learned:

* The default dot glyph for [morsey](https://www.npmjs.com/package/morsey) is `·`, not `.`